### PR TITLE
Fetch format on image field thumbnail and preview images

### DIFF
--- a/src-php/Fields/CloudinaryImage.php
+++ b/src-php/Fields/CloudinaryImage.php
@@ -24,10 +24,12 @@ class CloudinaryImage extends Image
         $this->thumbnail(function () {
             return $this->value ? cloudinary_image($this->value, [
                 'width' => 318,
+                'fetch_format' => 'auto',
             ], $this->disk) : null;
         })->preview(function () {
             return $this->value ? cloudinary_image($this->value, [
                 'width' => 318,
+                'fetch_format' => 'auto',
             ], $this->disk) : null;
         })->download(function () {
             $image_address = cloudinary_image($this->value);


### PR DESCRIPTION
We need to set the fetch format to auto on image field thumbnail and preview images to handle file formats such as .tiff.

I don't think this will cause any issues elsewhere.