### PR TITLE
Audio file upload name

### DIFF
--- a/src-php/Fields/CloudinaryAudio.php
+++ b/src-php/Fields/CloudinaryAudio.php
@@ -22,10 +22,7 @@ class CloudinaryAudio extends Audio
         parent::__construct($name, $attribute, $disk, $storageCallback);
 
         $this->storeAs(function (Request $request) {
-            $name = $request->{$this->attribute}->getClientOriginalName();
-            $ext = '.' . $request->{$this->attribute}->getClientOriginalExtension();
-
-            return sha1($name . time()) . $ext;
+            return $request->{$this->attribute}->getClientOriginalName();
         });
     }
 


### PR DESCRIPTION
Store client original name when uploading audio files

I'm not sure about backwards compatibility here @m2de , audio uploaded under the old naming convention will still work but apps using this package may be expecting the old format for new audio.  What do you think?