### PR TITLE
File size helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,13 @@ return Storage::disk('cloudinary')->url([
 ])
 ```
 
+### Max file size
+Cloudinary imposes maximum file sizes on images depending on your account plan.  At the time of writing the free plan allows images up to 10M.
+
+If a successfully uploaded image is transformed by cloudinary and upscaled past this file size, the download of that image will fail with a 400 error on the front end.
+
+This situation is especially likely to occur if working with GIF images which are typically quite large files at smaller resolutions, liable to upscaling by image processors.
+
 ## Using the CloudinaryAudio Field
 
 Simply use the `CloudinaryAudio` field in your Resource's fields. This component extends `davidpiesse/nova-audio` which in turn extends the default Nova File field so you can use it with all the same options as the standard field.

--- a/src-php/Fields/CloudinaryImage.php
+++ b/src-php/Fields/CloudinaryImage.php
@@ -40,6 +40,6 @@ class CloudinaryImage extends Image
             $path = pathinfo($model->{$this->attribute});
             Storage::disk($this->disk)->delete($path['filename']);
             return $this->columnsThatShouldBeDeleted();
-        });
+        })->help('Ensure when transformed to the size displayed on site, the image is less than the max file size for your Cloudinary account.');
     }
 }

--- a/src-php/Fields/CloudinaryImage.php
+++ b/src-php/Fields/CloudinaryImage.php
@@ -40,6 +40,6 @@ class CloudinaryImage extends Image
             $path = pathinfo($model->{$this->attribute});
             Storage::disk($this->disk)->delete($path['filename']);
             return $this->columnsThatShouldBeDeleted();
-        })->help('Ensure when transformed to the size displayed on site, the image is less than the max file size for your Cloudinary account.');
+        })->help(__('Ensure when transformed to the size displayed on site, the image is less than the max file size for your Cloudinary account.'));
     }
 }


### PR DESCRIPTION
I was asked to enable GIF support on a client's CMS.  This was recently enabled by the addition of fetch_format auto in release 1.1.1

However, when in use I quickly noticed an issue which took some digging to resolve.

The images on site were being resized to 600x800px. When a 250×208px (0.9M) GIF image was downloaded on the front end, the upscaling caused the image to exceed Cloudinarys Max File Size limitation, which is 10M on the clients free account.  This resulted in a broken image on the front end, with a 400 error when trying to access the image.

This PR adds a help field explaining that the downloaded image should not exceed this size limitation and an explanation of this situation in the Readme.