### PR TITLE
Add support for folders

### DIFF
--- a/src-php/Adapters/CloudinaryAdapter.php
+++ b/src-php/Adapters/CloudinaryAdapter.php
@@ -19,11 +19,13 @@ class CloudinaryAdapter extends CloudinaryBaseAdapter
      */
     public function writeStream($path, $resource, Config $config)
     {
-        $path = pathinfo($path)['filename'];
+        $pathinfo = pathinfo($path);
+        $folder = $pathinfo['dirname'];
+        $path = $pathinfo['filename'];
 
         $resource_metadata = stream_get_meta_data($resource);
-        $uploaded_metadata = Uploader::upload($resource_metadata['uri'], ['public_id' => $path, 'resource_type' => 'auto']);
-        
+        $uploaded_metadata = Uploader::upload($resource_metadata['uri'], ['folder' => $folder, 'public_id' => $path, 'resource_type' => 'auto']);
+
         return $uploaded_metadata;
     }
 

--- a/src-php/Adapters/CloudinaryAdapter.php
+++ b/src-php/Adapters/CloudinaryAdapter.php
@@ -23,8 +23,14 @@ class CloudinaryAdapter extends CloudinaryBaseAdapter
         $folder = $pathinfo['dirname'];
         $path = $pathinfo['filename'];
 
+        $options = ['public_id' => $path, 'resource_type' => 'auto'];
+
+        if ($folder != '.') {
+            $options['folder'] = $folder;
+        }
+
         $resource_metadata = stream_get_meta_data($resource);
-        $uploaded_metadata = Uploader::upload($resource_metadata['uri'], ['folder' => $folder, 'public_id' => $path, 'resource_type' => 'auto']);
+        $uploaded_metadata = Uploader::upload($resource_metadata['uri'], $options);
 
         return $uploaded_metadata;
     }


### PR DESCRIPTION
Per https://github.com/Silvanite/nova-field-cloudinary/issues/4

This will allow users to define what folder on Cloudinary given field should upload to. While default folder where the file is stored is set to be '/' in `Laravel\Nova\Fields\File` ($storagePath), one can override this behaviour by extending `CloudinaryImage` and defining `$storagePath` within the constructor.