### PR TITLE
Fix writeStream function to support folder path

### DIFF
--- a/src-php/Adapters/CloudinaryAdapter.php
+++ b/src-php/Adapters/CloudinaryAdapter.php
@@ -19,11 +19,20 @@ class CloudinaryAdapter extends CloudinaryBaseAdapter
      */
     public function writeStream($path, $resource, Config $config)
     {
-        $path = pathinfo($path)['filename'];
+        $pathInfo = pathinfo($path);
 
         $resource_metadata = stream_get_meta_data($resource);
-        $uploaded_metadata = Uploader::upload($resource_metadata['uri'], ['public_id' => $path, 'resource_type' => 'auto']);
-        
+        $uploaded_metadata = Uploader::upload(
+            $resource_metadata['uri'],
+            [
+                'public_id' => $pathInfo['filename'],
+                'resource_type' => 'auto',
+                'folder' => $pathInfo['dirname'] === '.'
+                    ? null
+                    : $pathInfo['dirname'],
+            ]
+        );
+
         return $uploaded_metadata;
     }
 


### PR DESCRIPTION
Doing
````php
CloudinaryImage::Make('Image',)->path('integration-partners');
````
does not currently work.
The file gets uploaded to the root path of cloudinary and all image references are broken.
This change respects the given path.